### PR TITLE
Implement reparenting to keep windows from overlapping placard

### DIFF
--- a/foowm/types.py
+++ b/foowm/types.py
@@ -49,6 +49,7 @@ class WindowGeometry:
 @dataclasses.dataclass
 class Client:
     window: Window
+    parent: Window
     geometry: WindowGeometry
     desired_geometry: WindowGeometry
     title: str

--- a/foowm/types.py
+++ b/foowm/types.py
@@ -48,7 +48,7 @@ class WindowGeometry:
 
 @dataclasses.dataclass
 class Client:
-    window: Window
+    target: Window
     parent: Window
     geometry: WindowGeometry
     desired_geometry: WindowGeometry
@@ -56,6 +56,20 @@ class Client:
     type: Optional[ClientType]
     floating: bool
     created_at: datetime.datetime
+    # This is literally how openbox handles reparenting unmap requests
+    ignore_unmaps: int = 0
+
+    # @vinhowe: Note that this is basically a workaround to allow us not to reparent the
+    # placard, only because python-xlib doesn't appear to have explicit support for
+    # everything we need to create new windows with transparent backgrounds.
+    # The "right" way to solve this would be to figure out how create transparent window
+    # backgrounds and just reparent everything.
+    @property
+    def window(self):
+        if not self.parent:
+            return self.target
+
+        return self.parent
 
 
 # Apparently python-xlib won't give us access to x and y on the standard

--- a/foowm/wm.py
+++ b/foowm/wm.py
@@ -216,7 +216,6 @@ class FootronWindowManager:
 
         logger.debug("Raising placard...")
         self._placard.window.raise_window()
-        self._display.sync()
 
     def _raise_loader(self):
         if not self._loader:
@@ -224,11 +223,11 @@ class FootronWindowManager:
 
         logger.debug("Raising loading window...")
         self._loader.window.raise_window()
-        self._display.sync()
 
     def _preserve_window_order(self):
         self._raise_loader()
         self._raise_placard()
+        self._display.sync()
 
     def _handle_map_request(self, ev: event.MapRequest):
         # Background on mapping and unmapping (last paragraph):
@@ -546,7 +545,6 @@ class FootronWindowManager:
             self._xembed_info_atom, self._xembed_info_atom, 32, [0, 1]
         )
         window.change_attributes(override_redirect=True)
-        self._display.sync()
 
         colormap = self._screen.default_colormap
         black_pixel = colormap.alloc_named_color("black").pixel
@@ -568,7 +566,6 @@ class FootronWindowManager:
             window.reparent(parent, 0, 0)
             parent.map()
             self._client_parents.add(parent.id)
-            self._display.sync()
             logger.debug(
                 f"ID of parent for window {hex(window.id)} is {hex(parent.id)}"
             )
@@ -595,7 +592,6 @@ class FootronWindowManager:
 
         self.scale_client(client, client.geometry)
         window.map()
-        self._display.sync()
         self._preserve_window_order()
         self._clients[client.target.id] = client
         self._set_ewmh_clients_list()
@@ -719,7 +715,8 @@ class FootronWindowManager:
                 width=max(geometry.width, 1),
                 height=max(geometry.height, 1),
             )
-            self._display.sync()
+            # Let preserve_window_order handle display syncing so we don't get any
+            # flickering
             self._preserve_window_order()
         except Exception:
             logger.exception(f"Error while scaling client {hex(client.window.id)}")
@@ -796,7 +793,6 @@ class FootronWindowManager:
                 break
 
     def _loop(self):
-        self._display.sync()
         while True:
             ev = self._display.next_event()
             if ev.type not in self._event_handlers:

--- a/foowm/wm.py
+++ b/foowm/wm.py
@@ -668,6 +668,8 @@ class FootronWindowManager:
                 height=max(geometry.height, 1),
             )
             client.window.configure(
+                x=geometry.x,
+                y=geometry.y,
                 width=max(geometry.width, 1),
                 height=max(geometry.height, 1),
             )

--- a/foowm/wm.py
+++ b/foowm/wm.py
@@ -619,9 +619,8 @@ class FootronWindowManager:
                 windows_skipped += 1
                 continue
 
-            client.window.kill_client()
-            # TODO: Do we need to remove these clients? Will they unmap themselves?
-            del self._clients[key]
+            # Killed client will request unmap, which will kill parent if one exists
+            client.target.kill_client()
             windows_killed += 1
         logger.debug(
             f"Cleared viewport: killed {windows_killed} window(s) and skipped {windows_skipped} window(s)"

--- a/foowm/wm.py
+++ b/foowm/wm.py
@@ -548,6 +548,9 @@ class FootronWindowManager:
         window.change_attributes(override_redirect=True)
         self._display.sync()
 
+        colormap = self._screen.default_colormap
+        black_pixel = colormap.alloc_named_color("black").pixel
+
         parent = None
         if client_type != ClientType.Placard:
             parent = self._root.create_window(
@@ -556,7 +559,11 @@ class FootronWindowManager:
                 1,
                 1,
                 X.CopyFromParent,
-                X.CopyFromParent,
+                self._screen.root_depth,
+                X.InputOutput,
+                background_pixel=black_pixel,
+                # TODO: Not sure if we need this
+                override_redirect=True
             )
             window.reparent(parent, 0, 0)
             parent.map()

--- a/foowm/wm.py
+++ b/foowm/wm.py
@@ -654,7 +654,7 @@ class FootronWindowManager:
         )
 
     def _set_ewmh_clients_list(self):
-        new_clients = self._clients.keys()
+        new_clients = map(lambda a: a.parent.id, self._clients.items())
         logger.debug(
             f"Updating _NET_CLIENT_LIST on root window: {list(map(hex, new_clients))}"
         )

--- a/foowm/wm.py
+++ b/foowm/wm.py
@@ -662,12 +662,12 @@ class FootronWindowManager:
 
         try:
             client.parent.configure(
+                x=geometry.x,
+                y=geometry.y,
                 width=max(geometry.width, 1),
                 height=max(geometry.height, 1),
             )
             client.window.configure(
-                x=geometry.x,
-                y=geometry.y,
                 width=max(geometry.width, 1),
                 height=max(geometry.height, 1),
             )

--- a/foowm/wm.py
+++ b/foowm/wm.py
@@ -662,8 +662,6 @@ class FootronWindowManager:
 
         try:
             client.parent.configure(
-                x=geometry.x,
-                y=geometry.y,
                 width=max(geometry.width, 1),
                 height=max(geometry.height, 1),
             )

--- a/foowm/wm.py
+++ b/foowm/wm.py
@@ -223,7 +223,7 @@ class FootronWindowManager:
             return
 
         logger.debug("Raising loading window...")
-        self._loader.window.raise_window()
+        self._loader.parent.raise_window()
         self._display.sync()
 
     def _preserve_window_order(self):

--- a/foowm/wm.py
+++ b/foowm/wm.py
@@ -668,6 +668,8 @@ class FootronWindowManager:
                 height=max(geometry.height, 1),
             )
             client.window.configure(
+                x=0,
+                y=0,
                 width=max(geometry.width, 1),
                 height=max(geometry.height, 1),
             )

--- a/foowm/wm.py
+++ b/foowm/wm.py
@@ -569,6 +569,7 @@ class FootronWindowManager:
             logger.debug(
                 f"ID of parent for window {hex(window.id)} is {hex(parent.id)}"
             )
+            self._display.sync()
         else:
             logger.debug("Not creating parent for placard client")
 

--- a/foowm/wm.py
+++ b/foowm/wm.py
@@ -707,7 +707,7 @@ class FootronWindowManager:
                 )
             else:
                 x = geometry.x
-                y = geometry.x
+                y = geometry.y
 
             client.target.configure(
                 x=x,


### PR DESCRIPTION
## Edit 5/9/2022

#4 implements the the ideal solution. All is right with the universe.

## Edit 11/20/2021

f6bf61e is a workaround that should let us merge this in. The comment below still describes the "ideal" solution so I leave it as reference.

---

I think we need to figure out how to get a 32 bit (transparent) `visual` parameter in window.create_window because `screen.root_visual` is 24 bit, which doesn't include an alpha channel. In examples like [this](https://gist.github.com/je-so/903479), they use XMatchVisualInfo, which `python-xlib` doesn't expose bindings to explicitly. We might just have to write our own bindings for it based on the code in `python-xlib`.

**We should definitely figure this out, I just can't justify spending any more time on it right now.**